### PR TITLE
Notebook hooks

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -34,7 +34,8 @@
 - id: black-nb
   name: black-nb
   description: 'Black: The uncompromising Python code formatter for Jupyter notebooks'
-  entry: black-nb -l 88
+  entry: black-nb
+  args: ['-l', '88']
   language: python
   language_version: python3
   require_serial: true

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -31,6 +31,21 @@
   entry: isort
   language: python
   types: [python]
+- id: black-nb
+  name: black-nb
+  description: 'Black: The uncompromising Python code formatter for Jupyter notebooks'
+  entry: black-nb -l 88
+  language: python
+  language_version: python3
+  require_serial: true
+  files: (?i)\.ipynb$
+- id: flake8-nb
+  name: flake8-nb
+  description: '`flake8_nb` is a command-line utility for enforcing style consistency across jupyter notebooks.'
+  entry: flake8_nb
+  language: python
+  files: (?i)\.ipynb$
+  require_serial: true
 - id: gofmt
   name: gofmt
   description: 'Automatically formats Go source code. Go needs to be installed'

--- a/README.md
+++ b/README.md
@@ -44,6 +44,23 @@ Add hooks depending on the languages you are using.
 These 3 hooks default configuration conflict with each other. A simple configuration that works can be
 found in `config/`. Copy `config/.isort.cfg` and `config/.flake8` to the root of your repo to get
 these hooks working together.
+
+#### Notebook specific hooks
+
+You can add notebook specific hooks by using the following.
+
+```
+  - id: black-nb
+    additional_dependencies:
+      - 'black-nb==0.3.0'
+  - id: flake8-nb
+    additional_dependencies:
+      - 'flake8_nb==v0.1.4'
+```
+
+Similar to previous hooks, you can copy `config/.flake8_nb` to the root of your repo to get these
+hooks working together.
+
 ### JavaScript
 
 ```yaml
@@ -52,7 +69,7 @@ these hooks working together.
 ```
 
 By default, `eslint` will not work with `prettier-standard`. A starting configuration that would work can be found
-in `config/`. Copy `config/.eslintrc` to the root of your repo and add some `addtional_dependencies` to the 
+in `config/`. Copy `config/.eslintrc` to the root of your repo and add `additional_dependencies` to the 
  `.pre-commit-config.yaml` file.
 
 ```

--- a/config/.flake8_nb
+++ b/config/.flake8_nb
@@ -1,0 +1,4 @@
+[flake8_nb]
+ignore = E203, E266, E501, W503
+max-line-length = 88
+max-complexity = 18

--- a/config/.flake8_nb
+++ b/config/.flake8_nb
@@ -1,4 +1,4 @@
 [flake8_nb]
-ignore = E203, E266, E501, W503
+ignore = E203, E266, E501, W503, W291, E303
 max-line-length = 88
 max-complexity = 18


### PR DESCRIPTION
I didn't include the new libraries as hard dependencies of the pre-commit hooks as they require installation of a bunch of large libraries like `jupyter`. This way installation time remains the same even if you are not using notebooks. 