### PR TITLE
Make isort compatible with black

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ repos:
     rev: 5.6.4
     hooks:
       - id: isort
+        args: ["--profile", "black"]
 ```
 
 The default flake8 configuration conflicts black. A simple configuration that


### PR DESCRIPTION
Hi. I modified the `.pre-commit-config.yaml` to make `isort` compatible with `black`. 

In the current pre-commit config, isort and black are conflicting. [Found the issue and solution here](https://github.com/PyCQA/isort/issues/1518) 

Isort insists this format:
```
from cost_categories import (applsj, asjdfsi, bananana, sdjffsd, sjdifjsl,
                             sjdil, yoyoyoyoy)
```
but Black have this format:
```
from cost_categories import (
    applsj,
    asjdfsi,
    bananana,
    sdjffsd,
    sjdifjsl,
    sjdil,
    yoyoyoyoy,
)
```
Since we want the black format, I've set the isort profile to black. 
```
- repo: https://github.com/pycqa/isort
    rev: 5.5.4
    hooks:
      - id: isort
        args: ["--profile", "black"]
```