### PR TITLE
Cleanup make help

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,38 +4,38 @@
 help:
 	@awk -F ':.*?## ' '/^[a-zA-Z]/ && NF==2 {printf "\033[36m  %-25s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
 
-dev: venv requirements-dev.txt ## setup dev environment
+dev: venv requirements-dev.txt  ## setup dev environment
 	venv/bin/pip-sync requirements-dev.txt
 
-venv: ## create virtual environment
+venv:  ## create virtual environment
 	python3 -m venv venv
 	venv/bin/pip3 install pip-tools
 
-requirements.txt: requirements.in ## create requirements
+requirements.txt: requirements.in  ## create requirements
 	venv/bin/pip-compile -o requirements.txt requirements.in
 
-requirements-dev.txt: requirements-dev.in ## create dev requirements
+requirements-dev.txt: requirements-dev.in  ## create dev requirements
 	venv/bin/pip-compile -o requirements-dev.txt requirements-dev.in
 
-clean: clean-build clean-pyc clean-test ## remove all build, test, coverage and Python artifacts
+clean: clean-build clean-pyc clean-test  ## remove all build, test, coverage and Python artifacts
 
-clean-build: ## remove build artifacts
+clean-build:  ## remove build artifacts
 	rm -fr build/
 	rm -fr dist/
 	rm -fr .eggs/
 
-clean-pyc: ## remove Python file artifacts
+clean-pyc:  ## remove Python file artifacts
 	find . -name '*.pyc' -exec rm -f {} +
 	find . -name '*.pyo' -exec rm -f {} +
 	find . -name '*~' -exec rm -f {} +
 	find . -name '__pycache__' -exec rm -fr {} +
 
-clean-test: ## remove test and coverage artifacts
+clean-test:  ## remove test and coverage artifacts
 	rm -fr .tox/
 	rm -f .coverage
 	rm -fr htmlcov/
 
-dist: clean ## builds source and wheel package
+dist: clean  ## build source and wheel package
 	python setup.py sdist
 	python setup.py bdist_wheel
 	ls -l dist

--- a/Makefile
+++ b/Makefile
@@ -1,31 +1,9 @@
 .PHONY: clean clean-test clean-pyc clean-build dev venv help requirements-dev.txt
 .DEFAULT_GOAL := help
 
-define BROWSER_PYSCRIPT
-import os, webbrowser, sys
-try:
-	from urllib import pathname2url
-except:
-	from urllib.request import pathname2url
-
-webbrowser.open("file://" + pathname2url(os.path.abspath(sys.argv[1])))
-endef
-export BROWSER_PYSCRIPT
-
-define PRINT_HELP_PYSCRIPT
-import re, sys
-
-for line in sys.stdin:
-	match = re.match(r'^([a-zA-Z_-]+):.*?## (.*)$$', line)
-	if match:
-		target, help = match.groups()
-		print("%-20s %s" % (target, help))
-endef
-export PRINT_HELP_PYSCRIPT
-BROWSER := python -c "$$BROWSER_PYSCRIPT"
-
 help:
-	@python -c "$$PRINT_HELP_PYSCRIPT" < $(MAKEFILE_LIST)
+	@awk -F ':.*?## ' '/^[a-zA-Z]/ && NF==2 {printf "\033[36m  %-25s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
+
 dev: venv requirements-dev.txt ## setup dev environment
 	venv/bin/pip-sync requirements-dev.txt
 


### PR DESCRIPTION
This replaces the Python script in `make help` with awk. 
In turn, this makes the Makefile more readable.  This also colorizes the help command:

![image](https://user-images.githubusercontent.com/4223564/119764235-9dd88b00-bee3-11eb-9aff-92615031ca20.png)


The snippet was forked from the [Makefile](https://github.com/thinkingmachines/streamlit-docker/blob/main/Makefile) in the streamlit-docker repo.
