### PR TITLE
Fix version tag from 2.1.2 to v2.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ We use `prettier` for base coding style tweaked with some
 ```yaml
 repos:
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: 2.1.2
+    rev: v2.1.2
     hooks:
       - id: prettier
         files: (?i)\.(json|js|jsx|ts|tsx)$


### PR DESCRIPTION
Repo for prettier has tag prefix of `v`. So using `2.1.2` as id instead of `v2.1.2` will cause an error.

https://github.com/pre-commit/mirrors-prettier/releases